### PR TITLE
fix regression w/ removal of gof_cancer rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "bmds_ui"
 license = {text = "MIT License"}
 authors = [
+  {name = "BMDS development team"},
   {name = "Andy Shapiro", email = "shapiro.andy@epa.gov"}
 ]
 readme = "README.md"
@@ -17,6 +18,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Topic :: Scientific/Engineering",
 ]
 requires-python = ">=3.11"
 dependencies = [

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -145,7 +145,7 @@ class TestContinuousIntegration(PlaywrightTestCase):
 
         page.locator('a:has-text("Logic")').click()
         expect(page.locator("#decision-logic tbody tr")).to_have_count(4)
-        expect(page.locator("#rule-table tbody tr")).to_have_count(18)
+        expect(page.locator("#rule-table tbody tr")).to_have_count(17)
 
         # Read-only
         page.get_by_role("button", name="Share").click()


### PR DESCRIPTION
The rule table now has one fewer rules for dichotomous data (see https://github.com/USEPA/BMDS/pull/60); fix test