### PR TITLE
fix admin logout

### DIFF
--- a/bmds_ui/templates/admin/base.html
+++ b/bmds_ui/templates/admin/base.html
@@ -3,10 +3,13 @@
 
 {% block userlinks %}
     {% if site_url %}
-        <a href="{{ site_url }}">{% translate 'View site' %}</a> /
+        <a href="{{ site_url }}">View site</a> /
     {% endif %}
-    <a href="{% url 'analytics' %}">{% translate 'Analytics' %}</a> /
-    <a href="{% url 'swagger' %}">{% translate 'Swagger' %}</a> /
-    <a href="{% url 'admin:logout' %}">{% translate 'Log out' %}</a>
+    <a href="{% url 'analytics' %}">Analytics</a> /
+    <a href="{% url 'swagger' %}">API</a> /
+    <form id="logout-form" method="post" action="{% url 'admin:logout' %}">
+        {% csrf_token %}
+        <button type="submit">Log out</button>
+    </form>
     {% include "admin/color_theme_toggle.html" %}
 {% endblock %}


### PR DESCRIPTION
The GET based logout was deprecated in django 5; fix our admin template so you can logout: https://docs.djangoproject.com/en/5.1/releases/4.1/#log-out-via-get

Template adapted from https://github.com/django/django/blob/5183f7c287a9a5d61ca1103b55166cda52d9c647/django/contrib/admin/templates/admin/base.html#L45-L63