### PR TITLE
UI updates from internal review

### DIFF
--- a/frontend/src/components/Data/DatasetForm.js
+++ b/frontend/src/components/Data/DatasetForm.js
@@ -127,14 +127,14 @@ class DatasetForm extends Component {
                             <th style={{width: 100}}>
                                 <Button
                                     className="btn btn-primary"
-                                    title="Add row"
+                                    title="Add Row"
                                     onClick={dataStore.addRow}
                                     icon="plus-circle"
                                 />
                                 &nbsp;
                                 <Button
                                     className="btn btn-info"
-                                    title="Load dataset from Excel"
+                                    title="Load Dataset from Excel"
                                     onClick={dataStore.toggleDatasetModal}
                                     icon="table"
                                 />

--- a/frontend/src/components/Data/TabularDatasetModal.js
+++ b/frontend/src/components/Data/TabularDatasetModal.js
@@ -14,14 +14,14 @@ class TabularDatasetModal extends Component {
         return (
             <Modal show={dataStore.showTabularModal} onHide={dataStore.toggleDatasetModal}>
                 <Modal.Header closeButton>
-                    <Modal.Title>Paste from Excel</Modal.Title>
+                    <Modal.Title>Load Dataset from Excel</Modal.Title>
                 </Modal.Header>
 
                 <Modal.Body>
                     <div className="form-group">
                         <p className="text-muted">
-                            Copy/paste data from Excel into the box below. Data must be all numeric
-                            with no headers or descriptive columns.
+                            Copy and paste data from Excel into the text area below. Data must be
+                            all numeric with no headers or descriptive columns.
                         </p>
 
                         {dataStore.tabularModalError ? (

--- a/frontend/src/components/Main/Actions/Actions.js
+++ b/frontend/src/components/Main/Actions/Actions.js
@@ -89,7 +89,7 @@ class Actions extends Component {
                                 className="dropdown-item"
                                 onClick={() => mainStore.downloadReport("excelUrl")}
                                 icon="file-excel"
-                                text="Download data"
+                                text="Download results"
                             />
                             <Button
                                 className="dropdown-item"

--- a/frontend/src/components/Main/DatasetModelOptionList/DatasetModelOption.js
+++ b/frontend/src/components/Main/DatasetModelOptionList/DatasetModelOption.js
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";

--- a/frontend/src/components/Main/DatasetModelOptionList/DatasetModelOption.js
+++ b/frontend/src/components/Main/DatasetModelOptionList/DatasetModelOption.js
@@ -21,7 +21,7 @@ const getDegreeText = (dtype, degree) => {
 class DatasetModelOption extends Component {
     render() {
         const {datasetId, store} = this.props,
-            option = store.options[datasetId],
+            option = _.find(store.options, d => datasetId === d.dataset_id),
             dataset = store.getDataset(option),
             {canEdit, updateOption} = store,
             dtype = store.getModelType,

--- a/frontend/src/components/common/FloatInput.js
+++ b/frontend/src/components/common/FloatInput.js
@@ -24,6 +24,11 @@ class FloatInput extends Component {
                     type="number"
                     value={value}
                     onChange={e => onChange(parseFloat(e.target.value))}
+                    onKeyDown={e => {
+                        if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+                            e.preventDefault();
+                        }
+                    }}
                 />
             </>
         );

--- a/frontend/src/components/common/IntegerInput.js
+++ b/frontend/src/components/common/IntegerInput.js
@@ -28,6 +28,11 @@ class IntegerInput extends Component {
                         const value = parseInt(e.target.value);
                         onChange(_.isFinite(value) ? value : "");
                     }}
+                    onKeyDown={e => {
+                        if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+                            e.preventDefault();
+                        }
+                    }}
                 />
             </>
         );

--- a/frontend/src/components/transforms/RaoScott/AboutModal.js
+++ b/frontend/src/components/transforms/RaoScott/AboutModal.js
@@ -70,12 +70,15 @@ class AboutModal extends Component {
                         modeled with standard dichotomous models as if they were not correlated.
                     </p>
                     <p>
-                        In order to apply the Rao-Scott transformation, both the numerator and
-                        denominator of a dose-level proportion are divided by <IM f="D" />. This
-                        results in what can be described as the <i>effective</i> sample size{" "}
-                        <IM f="\left({N_{f}}_{RS} = \frac{N_{f}}{D}\right)" />
-                        and the <i>effective</i> affected fetuses{" "}
-                        <IM f="\left({A_{f}}_{RS} = \frac{A_{f}}{D}\right)" />.
+                        In order to apply the Rao-Scott transformation, both the numerator (i.e.,
+                        the number of affected fetuses, <IM f="A_f" />) and denominator (i.e., the
+                        total number of fetuses or sample size, <IM f="N_f" />) of a dose-level
+                        proportion (<IM f="P_f = \frac{A_f}{N_f}" />) are divided by <IM f="D" />.
+                        This results in what can be described as the effective sample size (
+                        <IM f="{N_{f}}_{RS}=\frac{N_f}{D}" />) and the effective affected fetuses (
+                        <IM f="{AF_{f}}_{RS}=\frac{A_f}{D}" />
+                        ). Note that the proportion of animals responding does not change when
+                        applying the Rao-Scott transformation.
                     </p>
                     <p>
                         In order to provide BMDS users an approach to approximate <IM f="D" /> for

--- a/frontend/src/components/transforms/RaoScott/Output.js
+++ b/frontend/src/components/transforms/RaoScott/Output.js
@@ -14,7 +14,7 @@ const plotLayout = (title, xAxis, yAxis) => {
         height: 400,
         margin: {l: 50, r: 5, t: 75, b: 55},
         hovermode: "x unified",
-        title: {text: wrapText(title, 45)},
+        title: {text: wrapText(title, 45, "<br>")},
         legend: {x: 0.1, y: 1},
         xaxis: {title: {text: xAxis}},
         yaxis: {title: {text: yAxis}},

--- a/frontend/src/components/transforms/RaoScott/Output.js
+++ b/frontend/src/components/transforms/RaoScott/Output.js
@@ -7,13 +7,14 @@ import Plot from "react-plotly.js";
 import Button from "@/components/common/Button";
 import ClipboardButton from "@/components/common/ClipboardButton";
 import Table from "@/components/common/Table";
+import {wrapText} from "@/utils/wrapText";
 
 const plotLayout = (title, xAxis, yAxis) => {
     return {
         height: 400,
         margin: {l: 50, r: 5, t: 75, b: 55},
         hovermode: "x unified",
-        title: {text: title},
+        title: {text: wrapText(title, 45)},
         legend: {x: 0.1, y: 1},
         xaxis: {title: {text: xAxis}},
         yaxis: {title: {text: yAxis}},

--- a/frontend/src/components/transforms/RaoScott/Output.js
+++ b/frontend/src/components/transforms/RaoScott/Output.js
@@ -11,7 +11,7 @@ import Table from "@/components/common/Table";
 const plotLayout = (title, xAxis, yAxis) => {
     return {
         height: 400,
-        margin: {l: 50, r: 5, t: 75, b: 50},
+        margin: {l: 50, r: 5, t: 75, b: 55},
         hovermode: "x unified",
         title: {text: title},
         legend: {x: 0.1, y: 1},

--- a/frontend/src/constants/plotting.js
+++ b/frontend/src/constants/plotting.js
@@ -2,6 +2,7 @@ import _ from "lodash";
 
 import {continuousErrorBars, dichotomousErrorBars} from "@/utils/errorBars";
 import {ff} from "@/utils/formatters";
+import {wrapText} from "@/utils/wrapText";
 
 import {Dtype} from "./dataConstants";
 
@@ -73,7 +74,7 @@ export const getResponse = dataset => {
     },
     getDrLayout = function(dataset, selected, modal, hover) {
         let layout = _.cloneDeep(doseResponseLayout);
-        layout.title.text = dataset.metadata.name;
+        layout.title.text = wrapText(dataset.metadata.name, 45, "<br>");
         layout.xaxis.title.text = getDoseLabel(dataset);
         layout.yaxis.title.text = getResponseLabel(dataset);
         const xmin = _.min(dataset.doses) || 0,

--- a/frontend/src/constants/plotting.js
+++ b/frontend/src/constants/plotting.js
@@ -8,7 +8,7 @@ import {Dtype} from "./dataConstants";
 const doseResponseLayout = {
         autosize: true,
         legend: {yanchor: "top", y: 0.99, xanchor: "left", x: 0.01},
-        margin: {l: 50, r: 5, t: 50, b: 50},
+        margin: {l: 50, r: 5, t: 50, b: 55},
         showlegend: true,
         title: {
             text: "ADD",

--- a/frontend/src/stores/DataStore.js
+++ b/frontend/src/stores/DataStore.js
@@ -107,10 +107,9 @@ class DataStore {
     }
 
     @action.bound loadExampleData() {
-        const dataset = getExampleData(this.model_type),
-            currentDataset = this.datasets[this.selectedDatasetId];
-        _.extend(currentDataset, dataset);
-        this.updateOptionDegree(dataset);
+        const exampleData = getExampleData(this.model_type);
+        _.extend(this.selectedDataset, exampleData);
+        this.updateOptionDegree(this.selectedDataset);
     }
 
     @action.bound cleanRows() {

--- a/frontend/src/utils/wrapText.js
+++ b/frontend/src/utils/wrapText.js
@@ -1,0 +1,34 @@
+export const wrapText = (text, maxLength = 80, join = "\n") => {
+    /**
+     * Wraps a given text to a specific length.
+     * @param {string} text - The input text to wrap.
+     * @param {number} maxLength - The maximum line length.
+     * @param {string} join - The string used to join wrapped lines.
+     * @returns {string} - The wrapped text.
+     */
+    if (typeof text !== "string" || typeof maxLength !== "number" || maxLength <= 0) {
+        throw new Error(
+            "Invalid input: text must be a string and maxLength must be a positive number."
+        );
+    }
+
+    const result = [];
+    let currentLine = "";
+
+    for (const word of text.split(" ")) {
+        if ((currentLine + word).length > maxLength) {
+            if (currentLine.length > 0) {
+                result.push(currentLine.trim());
+            }
+            currentLine = word + " ";
+        } else {
+            currentLine += word + " ";
+        }
+    }
+
+    if (currentLine.length > 0) {
+        result.push(currentLine.trim());
+    }
+
+    return result.join(join);
+};

--- a/frontend/tests/utils/wrapText.test.js
+++ b/frontend/tests/utils/wrapText.test.js
@@ -1,0 +1,30 @@
+import {wrapText} from "../../src/utils/wrapText";
+import assert from "../helpers";
+
+describe("wrapText", () => {
+    it("should wrap text at the max length", () => {
+        assert.equal(wrapText("text text", 4), "text\ntext");
+    });
+
+    it("should handle text shorter than max length", () => {
+        assert.equal(wrapText("text", 2), "text");
+    });
+
+    it("should handle exact max length text", () => {
+        assert.equal(wrapText("text", 4), "text");
+    });
+
+    it("should use the provided join string", () => {
+        assert.equal(wrapText("text text", 4, " | "), "text | text");
+    });
+
+    it("should handle empty text", () => {
+        const text = "";
+        assert.equal(wrapText(text, 10), text);
+    });
+
+    it("should handle single long word", () => {
+        const text = "Supercalifragilisticexpialidocious";
+        assert.equal(wrapText(text, 10), text);
+    });
+});


### PR DESCRIPTION
A number of user-interface edits and revisions based on internal review of the application.  I provided a number of screenshots to better demonstrate the changes.


From Reviewer 1:

- [x] Change "Paste from Excel" pop up window title to "Load from Excel" to match the hover text for the button. 

| Old | New |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/3ebb0edb-2ba2-4069-a551-14da53dcce0e) | ![image](https://github.com/user-attachments/assets/73ad0686-1f0e-4b1f-b1e4-91ce4579a751) |

From Reviewer 2:

- [x] In the Rao-Scott transformation tool About text, change the paragraph that starts "In order to apply..." to the following:   "In order to apply the Rao-Scott transformation, both the numerator (i.e., the number of affected fetuses, Af) and denominator (i.e., the total number of fetuses or sample size, Nf) of a dose-level proportion (Pf = Af/Nf) are divided by D. This results in what can be described as the effective sample size (NfRS=Nf/D) and the effective affected fetuses (AfRS=Af/D).  Note that the proportion of animals responding does not change when applying the Rao-Scott transformation.".

| Old | New |
| --- | --- |
|![image](https://github.com/user-attachments/assets/66520f44-bdf4-4fa0-9cf1-e66bc926dadb)|![image](https://github.com/user-attachments/assets/5fabd4b0-b44b-475d-be6e-335741007185)|

From Reviewer 3:

- [x] App loads blank screen:  Create a new BMDS analysis, change to Data tab, created new dataset 1, create new dataset 2, delete dataset 1, switch to settings tab.

- [x] Load example dataset not working sometimes:   Create a new BMDS analysis, change to dichotomous data type in settings tab, change to data tab, create new dataset 1, create new dataset 2, delete dataset 1, try “Load an example dataset” link

- [x] Disable function to change values in dataset table by clicking up or down arrows:  In the data tab, when a cell in the data matrix is selected tapping up or down on the arrow keys. This is a neat feature but is unexpected and is more likely to result in advertent changes to data than to be a valid way to input or change a value. I would recommend disabling this feature if possible.

- [x] Investigate plotly title axes title issue:  The plotly margins (on the data tab, but I think basically all the figures) could be adjusted slightly to not cut off the bottom of parentheses for the x-axis label (or the x-axis lablel could be moved up slightly.

- [x] The plotly margins (on the data tab, but I think basically all the figures) could be adjusted slightly to not cut off the bottom of parentheses for the x-axis label (or the x-axis lablel could be moved up slightly. See figure:  Seems minor, fix if easy, don’t if not.

- [x] The plotly titles could be fixed to prevent very long titles from being cut off: Entering a (reasonably) long dataset name results in truncated plot titles. I think having the plot wrap the title and squish the figure down to compensate would be better. In this example the dataset title is, “Dataset 1 This is a really long name to test what will happen with a long name”.

![image](https://github.com/user-attachments/assets/a5fa3984-6ad1-45b6-b354-2a68c8da4d83)

- [x] The “Reporting -> Download Data” Action is great, but I thought it was confusing because the “Data” tab is specifically input data, whereas here “data” refers to the output analysis data. Maybe “analysis data” could work for the output and “analysis json” could work for that option?   (from Allen:  maybe change to "Download Analysis Results"?)

![image](https://github.com/user-attachments/assets/9edd3ee5-896c-4dc7-b475-beb8d78e4af1)

- [x] Nested dichotomous data does not check for negative values in dose (and will fail with an opaque error message). Dichotomous and Continuous properly check the data input and fail to save analysis with an error message explaining why for negative values.


