### PR TITLE
render invalid Excel and Word reports

### DIFF
--- a/bmds_ui/common/renderers.py
+++ b/bmds_ui/common/renderers.py
@@ -1,8 +1,11 @@
 import json
 from io import BytesIO
-from typing import NamedTuple
+from typing import NamedTuple, TypeAlias
 
+import pandas as pd
 from rest_framework.renderers import BaseRenderer
+
+from pybmds.reporting.styling import Report
 
 
 class TxtRenderer(BaseRenderer):
@@ -18,27 +21,56 @@ class BinaryFile(NamedTuple):
     filename: str
 
 
+BinaryRendererData: TypeAlias = list | dict | BinaryFile
+
+
+def write_error_docx(context: str = "") -> BinaryFile:
+    report = Report.build_default()
+    report.document.add_heading("An error occurred", 1)
+    report.document.add_paragraph(context)
+    file = BytesIO()
+    report.document.save(file)
+    return BinaryFile(data=file, filename="error")
+
+
+def write_error_xlsx(context: str = "") -> BinaryFile:
+    content = json.dumps(context, indent=2)
+    df = pd.DataFrame({"Status": [content]})
+    file = BytesIO()
+    with pd.ExcelWriter(file) as writer:
+        df.to_excel(writer, index=False)
+    return BinaryFile(data=file, filename="error")
+
+
 class XlsxRenderer(BaseRenderer):
     media_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     format = "xlsx"
 
-    def render(self, dataset: dict | BinaryFile, media_type=None, renderer_context=None):
-        if isinstance(dataset, dict):
-            return json.dumps(dataset).encode()
+    def render(self, data: BinaryRendererData, accepted_media_type=None, renderer_context=None):
+        if not isinstance(data, BinaryFile):
+            try:
+                context = json.dumps(data, indent=2)
+            except TypeError:
+                context = "An error occurred"
+            data = write_error_xlsx(context)
 
         response = renderer_context["response"]
-        response["Content-Disposition"] = f'attachment; filename="{dataset.filename}.xlsx"'
-        return dataset.data.getvalue()
+        response["Content-Disposition"] = f'attachment; filename="{data.filename}.xlsx"'
+        return data.data.getvalue()
 
 
 class DocxRenderer(BaseRenderer):
     media_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     format = "docx"
 
-    def render(self, dataset: dict | BinaryFile, media_type=None, renderer_context=None):
-        if isinstance(dataset, dict):
-            return json.dumps(dataset).encode()
+    def render(self, data: BinaryRendererData, accepted_media_type=None, renderer_context=None):
+        if not isinstance(data, BinaryFile):
+            try:
+                context = json.dumps(data, indent=2)
+            except TypeError:
+                context = "An error occurred"
+            data = write_error_docx(context)
 
         response = renderer_context["response"]
-        response["Content-Disposition"] = f'attachment; filename="{dataset.filename}.docx"'
-        return dataset.data.getvalue()
+        response["Content-Disposition"] = f'attachment; filename="{data.filename}.docx"'
+        return data.data.getvalue()

--- a/tests/common/test_renderers.py
+++ b/tests/common/test_renderers.py
@@ -50,7 +50,6 @@ class TestExcelRenderer:
     def test_error(self):
         resp = Response()
         error = {"test": "here"}
-        resp = Response()
         data = renderers.XlsxRenderer().render(data=error, renderer_context={"response": resp})
         df2 = pd.read_excel(BytesIO(data))
         assert df2.Status[0] == '"{\\n  \\"test\\": \\"here\\"\\n}"'

--- a/tests/common/test_renderers.py
+++ b/tests/common/test_renderers.py
@@ -1,0 +1,56 @@
+from io import BytesIO
+
+import pandas as pd
+from docx import Document
+from rest_framework.response import Response
+
+from bmds_ui.common import renderers
+from pybmds.reporting.styling import Report
+
+
+class TestDocxRenderer:
+    def test_success(self):
+        report = Report.build_default()
+        report.document.add_heading("Test123")
+        file = BytesIO()
+        report.document.save(file)
+        file = renderers.BinaryFile(data=file, filename="test")
+
+        resp = Response()
+        data = renderers.DocxRenderer().render(data=file, renderer_context={"response": resp})
+        d2 = Document(BytesIO(data))
+        assert resp["Content-Disposition"] == 'attachment; filename="test.docx"'
+        assert d2.paragraphs[0].text == "Test123"
+
+    def test_error(self):
+        resp = Response()
+        error = {"test": "here"}
+        b = renderers.DocxRenderer().render(data=error, renderer_context={"response": resp})
+        d2 = Document(BytesIO(b))
+        assert resp["Content-Disposition"] == 'attachment; filename="error.docx"'
+        assert d2.paragraphs[0].text == "An error occurred"
+        assert d2.paragraphs[1].text == '{\n  "test": "here"\n}'
+
+
+class TestExcelRenderer:
+    def test_success(self):
+        df = pd.DataFrame(columns=["a", "b"], data=[[1, 2], [4, 5]])
+        f = BytesIO()
+        with pd.ExcelWriter(f) as writer:
+            df.to_excel(writer, index=False)
+        file = renderers.BinaryFile(data=f, filename="test")
+
+        resp = Response()
+        data = renderers.XlsxRenderer().render(data=file, renderer_context={"response": resp})
+
+        df2 = pd.read_excel(BytesIO(data))
+        assert df2.to_dict(orient="records") == [{"a": 1, "b": 2}, {"a": 4, "b": 5}]
+        assert resp["Content-Disposition"] == 'attachment; filename="test.xlsx"'
+
+    def test_error(self):
+        resp = Response()
+        error = {"test": "here"}
+        resp = Response()
+        data = renderers.XlsxRenderer().render(data=error, renderer_context={"response": resp})
+        df2 = pd.read_excel(BytesIO(data))
+        assert df2.Status[0] == '"{\\n  \\"test\\": \\"here\\"\\n}"'


### PR DESCRIPTION
Always return an xlsx or docx file, even if the renderer is returning a validation error.