### PR TITLE
update github action with new pybmds build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,6 @@ jobs:
         DJANGO_DB_PORT: ${{ job.services.postgres.ports[5432] }} # get randomly assigned published port
         DJANGO_CACHE_LOCATION: redis://localhost:6379/0
       run: |
-        export "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH"
         coverage run -m pytest --record-mode=none
         echo "# Python coverage report" >> $GITHUB_STEP_SUMMARY
         coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
@@ -201,7 +200,7 @@ jobs:
         path: venv/dist
     - name: Install bmds_ui
       run: |
-        uv pip install --system "venv/dist/*.whl | head -n 1)"
+        uv pip install --system venv/dist/*.whl
         uv pip install --system -v -e ".[pg,dev]"
         playwright install --with-deps chromium
 
@@ -210,14 +209,12 @@ jobs:
       id: test
       continue-on-error: true
       run: |
-        export "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH"
         py.test -sv tests/integration/
     - name: run integration tests (retry)
       if: steps.test.outcome=='failure'
       id: retry
       continue-on-error: true
       run: |
-        export "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH"
         py.test -sv tests/integration/
     - name: set status
       if: always()
@@ -229,9 +226,8 @@ jobs:
         fi
     - name: build wheel
       run: |
-        export "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH"
         manage.py set_git_commit
-        flit build --no-use-vcs
+        uv build --wheel
     - name: Upload wheel
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,65 +68,60 @@ jobs:
         ./vcpkg/bootstrap-vcpkg.sh
         ./vcpkg/vcpkg install --host-triplet="$VCPKG_HOST_TRIPLET" --overlay-ports=./vendor/ports
 
-    # - uses: actions/setup-python@v5
-    #   with:
-    #     python-version: "3.13"
-    #     cache: pip
-    # - name: Install uv
-    #   uses: astral-sh/setup-uv@v5
-    #   with:
-    #     cache-dependency-glob: "**/pyproject.toml"
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.13"
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        cache-dependency-glob: "**/pyproject.toml"
 
-    # - name: Build pybmds
-    #   run: |
-    #     cd venv
-    #     uv pip install pybind11==3.0.0 --target=./pybind11
-    #     export CMAKE_PREFIX_PATH=${{ github.workspace }}/pybind11/pybind11/share/cmake
-    #     export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
-    #     uv pip install --system -v -e ".[dev,docs]"
-    #     stubgen -p pybmds.bmdscore -o src
-    #     ruff format src/pybmds/bmdscore.pyi
-    #     python -c "import pybmds; print(pybmds.bmdscore.version())"
+    - name: Build pybmds
+      run: |
+        cd venv
+        uv pip install pybind11==3.0.0 --target=./pybind11
+        export CMAKE_PREFIX_PATH=${{ github.workspace }}/pybind11/pybind11/share/cmake
+        export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
+        uv build ---wheel
 
-    # - name: Install bmds_ui
-    #   run: |
-    #     python -m pip install -e ".[pg,dev]"
-    # - name: loc
-    #   run: |
-    #     sudo apt-get install -y cloc
-    #     echo "# Lines of Code Report" >> $GITHUB_STEP_SUMMARY
-    #     poe -q loc >> $GITHUB_STEP_SUMMARY
-    # - name: lint
-    #   run: |
-    #     poe lint-py
-    # - name: test
-    #   env:
-    #     DJANGO_DB_NAME: bmds-online-test
-    #     DJANGO_DB_USER: bmds
-    #     DJANGO_DB_PW: password
-    #     DJANGO_DB_HOST: localhost
-    #     DJANGO_DB_PORT: ${{ job.services.postgres.ports[5432] }} # get randomly assigned published port
-    #     DJANGO_CACHE_LOCATION: redis://localhost:6379/0
-    #   run: |
-    #     export "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH"
-    #     coverage run -m pytest --record-mode=none
-    #     echo "# Python coverage report" >> $GITHUB_STEP_SUMMARY
-    #     coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
-    #     coverage html -d coverage -i
-    # - name: Upload pybmds wheel
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: pybmds
-    #     path: |
-    #       venv/dist
-    #       venv/tools
-    #     retention-days: 1
-    # - name: Upload Coverage Report
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: coverage
-    #     path: coverage
-    #     retention-days: 14
+    - name: Install bmds_ui
+      run: |
+        uv pip install --system "venv/dist/*.whl | head -n 1)"
+        uv pip install --system -v -e ".[pg,dev]"
+    - name: loc
+      run: |
+        sudo apt-get install -y cloc
+        echo "# Lines of Code Report" >> $GITHUB_STEP_SUMMARY
+        poe -q loc >> $GITHUB_STEP_SUMMARY
+    - name: lint
+      run: |
+        poe lint-py
+    - name: test
+      env:
+        DJANGO_DB_NAME: bmds-online-test
+        DJANGO_DB_USER: bmds
+        DJANGO_DB_PW: password
+        DJANGO_DB_HOST: localhost
+        DJANGO_DB_PORT: ${{ job.services.postgres.ports[5432] }} # get randomly assigned published port
+        DJANGO_CACHE_LOCATION: redis://localhost:6379/0
+      run: |
+        export "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH"
+        coverage run -m pytest --record-mode=none
+        echo "# Python coverage report" >> $GITHUB_STEP_SUMMARY
+        coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
+        coverage html -d coverage -i
+    - name: Upload pybmds wheel
+      uses: actions/upload-artifact@v4
+      with:
+        name: pybmds
+        path: venv/dist
+        retention-days: 1
+    - name: Upload Coverage Report
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage
+        path: coverage
+        retention-days: 14
 
   frontend:
     name: frontend
@@ -161,7 +156,7 @@ jobs:
   integration:
     name: integration
     needs: [backend, frontend]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     services:
       postgres:
@@ -189,7 +184,11 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: "3.13"
-        cache: pip
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        cache-dependency-glob: "**/pyproject.toml"
+
     - name: Download JS build
       uses: actions/download-artifact@v4
       with:
@@ -199,17 +198,13 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: pybmds
-        path: venv
-    - name: Install pybmds
-      run: |
-        source ./venv/tools/linux_ci_setup.sh
-        source ./venv/tools/linux_ci_env.sh
-        python -m pip install "$(ls ./venv/dist/*.whl | head -n 1)"
+        path: venv/dist
     - name: Install bmds_ui
       run: |
-        pip install -U pip wheel
-        pip install -e ".[pg,dev]"
+        uv pip install --system "venv/dist/*.whl | head -n 1)"
+        uv pip install --system -v -e ".[pg,dev]"
         playwright install --with-deps chromium
+
     # https://github.community/t/how-to-retry-a-failed-step-in-github-actions-workflow/125880
     - name: run integration tests
       id: test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
         uv pip install pybind11==3.0.0 --target=./pybind11
         export CMAKE_PREFIX_PATH=${{ github.workspace }}/pybind11/pybind11/share/cmake
         export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
-        uv build ---wheel
+        uv build --wheel
 
     - name: Install bmds_ui
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
       if: steps.cache-vcpkg-deps.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        cd bmds
+        cd venv
         ./vcpkg/bootstrap-vcpkg.sh
         ./vcpkg/vcpkg install --host-triplet="$VCPKG_HOST_TRIPLET" --overlay-ports=./vendor/ports
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   backend:
     name: backend
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     services:
       postgres:
@@ -43,57 +43,87 @@ jobs:
         repository: USEPA/BMDS
         path: venv
         ref: main
-    - uses: actions/setup-python@v5
+
+    - name: Cache vcpkg dependencies
+      id: cache-vcpkg-deps
+      uses: actions/cache@v4
       with:
-        python-version: "3.13"
-        cache: pip
-    - name: Install pybmds
-      run: |
-        python -m pip install -U pip wheel setuptools
-        cd venv
-        source ./tools/linux_ci_setup.sh
-        source ./tools/linux_ci_env.sh
-        python setup.py bdist_wheel
-        python -m pip install "$(ls dist/*.whl | head -n 1)"
-    - name: Install bmds_ui
-      run: |
-        python -m pip install -e ".[pg,dev]"
-    - name: loc
-      run: |
-        sudo apt-get install -y cloc
-        echo "# Lines of Code Report" >> $GITHUB_STEP_SUMMARY
-        poe -q loc >> $GITHUB_STEP_SUMMARY
-    - name: lint
-      run: |
-        poe lint-py
-    - name: test
-      env:
-        DJANGO_DB_NAME: bmds-online-test
-        DJANGO_DB_USER: bmds
-        DJANGO_DB_PW: password
-        DJANGO_DB_HOST: localhost
-        DJANGO_DB_PORT: ${{ job.services.postgres.ports[5432] }} # get randomly assigned published port
-        DJANGO_CACHE_LOCATION: redis://localhost:6379/0
-      run: |
-        export "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH"
-        coverage run -m pytest --record-mode=none
-        echo "# Python coverage report" >> $GITHUB_STEP_SUMMARY
-        coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
-        coverage html -d coverage -i
-    - name: Upload pybmds wheel
-      uses: actions/upload-artifact@v4
+        path: venv/vcpkg_installed
+        key: vcpkg-${{ runner.os }}-${{ hashFiles('vcpkg.json') }}
+    - name: Acquire vcpkg
+      if: steps.cache-vcpkg-deps.outputs.cache-hit != 'true'
+      uses: actions/checkout@v4
       with:
-        name: pybmds
-        path: |
-          venv/dist
-          venv/tools
-        retention-days: 1
-    - name: Upload Coverage Report
-      uses: actions/upload-artifact@v4
-      with:
-        name: coverage
-        path: coverage
-        retention-days: 14
+        repository: "Microsoft/vcpkg"
+        path: venv/vcpkg
+        ref: c9c17dcea3016bc241df0422e82b8aea212dcb93
+    - name: Install libraries with vcpkg.json
+      if: steps.cache-vcpkg-deps.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd bmds
+        ./vcpkg/bootstrap-vcpkg.sh
+        ./vcpkg/vcpkg install --host-triplet="$VCPKG_HOST_TRIPLET" --overlay-ports=./vendor/ports
+
+    # - uses: actions/setup-python@v5
+    #   with:
+    #     python-version: "3.13"
+    #     cache: pip
+    # - name: Install uv
+    #   uses: astral-sh/setup-uv@v5
+    #   with:
+    #     cache-dependency-glob: "**/pyproject.toml"
+
+    # - name: Build pybmds
+    #   run: |
+    #     cd venv
+    #     uv pip install pybind11==3.0.0 --target=./pybind11
+    #     export CMAKE_PREFIX_PATH=${{ github.workspace }}/pybind11/pybind11/share/cmake
+    #     export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
+    #     uv pip install --system -v -e ".[dev,docs]"
+    #     stubgen -p pybmds.bmdscore -o src
+    #     ruff format src/pybmds/bmdscore.pyi
+    #     python -c "import pybmds; print(pybmds.bmdscore.version())"
+
+    # - name: Install bmds_ui
+    #   run: |
+    #     python -m pip install -e ".[pg,dev]"
+    # - name: loc
+    #   run: |
+    #     sudo apt-get install -y cloc
+    #     echo "# Lines of Code Report" >> $GITHUB_STEP_SUMMARY
+    #     poe -q loc >> $GITHUB_STEP_SUMMARY
+    # - name: lint
+    #   run: |
+    #     poe lint-py
+    # - name: test
+    #   env:
+    #     DJANGO_DB_NAME: bmds-online-test
+    #     DJANGO_DB_USER: bmds
+    #     DJANGO_DB_PW: password
+    #     DJANGO_DB_HOST: localhost
+    #     DJANGO_DB_PORT: ${{ job.services.postgres.ports[5432] }} # get randomly assigned published port
+    #     DJANGO_CACHE_LOCATION: redis://localhost:6379/0
+    #   run: |
+    #     export "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH"
+    #     coverage run -m pytest --record-mode=none
+    #     echo "# Python coverage report" >> $GITHUB_STEP_SUMMARY
+    #     coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
+    #     coverage html -d coverage -i
+    # - name: Upload pybmds wheel
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: pybmds
+    #     path: |
+    #       venv/dist
+    #       venv/tools
+    #     retention-days: 1
+    # - name: Upload Coverage Report
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: coverage
+    #     path: coverage
+    #     retention-days: 14
 
   frontend:
     name: frontend

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
 
     - name: Install bmds_ui
       run: |
-        uv pip install --system "venv/dist/*.whl | head -n 1)"
+        uv pip install --system venv/dist/*.whl
         uv pip install --system -v -e ".[pg,dev]"
     - name: loc
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,9 @@ jobs:
         ports:
         - 6379:6379
 
+    env:
+      VCPKG_HOST_TRIPLET: x64-linux
+
     steps:
     - name: Checkout bmds-ui
       uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
       run: |
         cd venv
         uv pip install pybind11==3.0.0 --target=./pybind11
-        export CMAKE_PREFIX_PATH=${{ github.workspace }}/pybind11/pybind11/share/cmake
+        export CMAKE_PREFIX_PATH=$(pwd)/pybind11/pybind11/share/cmake
         export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
         uv build --wheel
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: venv/vcpkg_installed
-        key: vcpkg-${{ runner.os }}-${{ hashFiles('vcpkg.json') }}
+        key: vcpkg-${{ runner.os }}-${{ hashFiles('venv/vcpkg.json') }}
     - name: Acquire vcpkg
       if: steps.cache-vcpkg-deps.outputs.cache-hit != 'true'
       uses: actions/checkout@v4


### PR DESCRIPTION
Updates the GitHub Actions workflow to implement the new build system from USEPA/BMDS/pull/128, replacing the custom Linux CI setup with a vcpkg-based dependency management approach and modernizing the build toolchain.

Migrates from Ubuntu 22.04 to 24.04 across all jobs
Replaces custom Linux CI setup scripts with vcpkg for C++ dependency management